### PR TITLE
Patch for URI

### DIFF
--- a/lib/presta_shop/uri_handler.rb
+++ b/lib/presta_shop/uri_handler.rb
@@ -19,7 +19,7 @@ module PrestaShop
       # Add http:// scheme if the scheme is missing from the base url
       base_url = 'http://' + base_url if URI.parse(base_url).scheme.nil?
 
-      uri = URI.join base_url, API_PATH
+      uri = URI.join base_url.gsub(%r{api/?}), API_PATH
       return uri.to_s
     end
   end

--- a/lib/presta_shop/uri_handler.rb
+++ b/lib/presta_shop/uri_handler.rb
@@ -19,7 +19,7 @@ module PrestaShop
       # Add http:// scheme if the scheme is missing from the base url
       base_url = 'http://' + base_url if URI.parse(base_url).scheme.nil?
 
-      uri = URI.join base_url.gsub(%r{api/?\z}), API_PATH
+      uri = URI.join base_url.gsub(%r{api/?\z}, ''), API_PATH
       return uri.to_s
     end
   end

--- a/lib/presta_shop/uri_handler.rb
+++ b/lib/presta_shop/uri_handler.rb
@@ -19,7 +19,7 @@ module PrestaShop
       # Add http:// scheme if the scheme is missing from the base url
       base_url = 'http://' + base_url if URI.parse(base_url).scheme.nil?
 
-      uri = URI.join base_url.gsub(%r{api/?}), API_PATH
+      uri = URI.join base_url.gsub(%r{api/?\z}), API_PATH
       return uri.to_s
     end
   end

--- a/lib/presta_shop/uri_handler.rb
+++ b/lib/presta_shop/uri_handler.rb
@@ -4,7 +4,7 @@ module PrestaShop
 
   # Handle URIs, converting from base Prestashop URL to API URIs
   class UriHandler
-    API_PATH = 'api/'
+    API_PATH = ''
 
     # Convert a base Prestashop URL to its API URI
     # @param base_url [String] a Prestashop base URL. Do not append "/api", it is appended internally. E.g. use
@@ -19,8 +19,7 @@ module PrestaShop
       # Add http:// scheme if the scheme is missing from the base url
       base_url = 'http://' + base_url if URI.parse(base_url).scheme.nil?
 
-      uri = URI.join base_url.gsub(%r{api/?\z}, ''), API_PATH
-      return uri.to_s
+      URI base_url.to_s
     end
   end
 end


### PR DESCRIPTION
This was the URI I was getting.
```
[45, 54] in /home/jeff/.rvm/gems/ruby-2.3.3@disputer/gems/presta_shop-0.1.2/lib/presta_shop.rb
   45:   # @return [boolean] true if key is valid, false otherwise
   46:   # @raise [RestClient::Exception] if there is an error during HTTP GET
   47:   # @raise [StandardError] if a response different from 200 or 401 is received (not counting redirect responses,
   48:   #   which will be followed)
   49:   def self.valid_key?(url, key)
=> 50:     api_uri = UriHandler.api_uri url
   51:     res = RestClient::Resource.new api_uri, user: key, password: ''
   52:     begin
   53:       response = res.get
   54:       if response.code == 200 # OK response means API key is valid
(byebug) UriHandler.api_uri url
"http://127.0.0.1/presta/api/api/"
```